### PR TITLE
Ptrmu publish individual marker tfs

### DIFF
--- a/fiducial_vlam/include/fiducial_math.hpp
+++ b/fiducial_vlam/include/fiducial_math.hpp
@@ -52,9 +52,9 @@ namespace fiducial_vlam
     std::shared_ptr<CvFiducialMath> cv_;
 
   public:
-    FiducialMath(const CameraInfo &camera_info);
+    explicit FiducialMath(const CameraInfo &camera_info);
 
-    FiducialMath(const sensor_msgs::msg::CameraInfo &camera_info_msg);
+    explicit FiducialMath(const sensor_msgs::msg::CameraInfo &camera_info_msg);
 
     TransformWithCovariance solve_t_camera_marker(const Observation &observation, double marker_length);
 

--- a/fiducial_vlam/include/map.hpp
+++ b/fiducial_vlam/include/map.hpp
@@ -122,6 +122,11 @@ namespace fiducial_vlam
                                                       const std::vector<TransformWithCovariance> &t_map_markers,
                                                       std::shared_ptr<cv_bridge::CvImage> &color_marked,
                                                       FiducialMath &fm);
+
+    std::vector<TransformWithCovariance> markers_t_map_cameras(
+      const Observations &observations,
+      const std::vector<TransformWithCovariance> &t_map_markers,
+      FiducialMath &fm);
   };
 
 // ==============================================================================

--- a/fiducial_vlam/include/map.hpp
+++ b/fiducial_vlam/include/map.hpp
@@ -30,7 +30,7 @@ namespace fiducial_vlam
   class Marker
   {
     // The id of the marker
-    int id_;
+    int id_{};
 
     // The pose of the marker in the map frame
     TransformWithCovariance t_map_marker_;
@@ -39,7 +39,7 @@ namespace fiducial_vlam
     bool is_fixed_{false};
 
     // Count of updates
-    int update_count_;
+    int update_count_{};
 
   public:
     Marker() = default;

--- a/fiducial_vlam/include/observation.hpp
+++ b/fiducial_vlam/include/observation.hpp
@@ -97,7 +97,7 @@ namespace fiducial_vlam
 
     void add(const Observation observation)
     {
-      observations_.emplace_back(std::move(observation));
+      observations_.emplace_back(observation);
     }
 
     fiducial_vlam_msgs::msg::Observations to_msg(std_msgs::msg::Header::_stamp_type stamp,

--- a/fiducial_vlam/include/transform_with_covariance.hpp
+++ b/fiducial_vlam/include/transform_with_covariance.hpp
@@ -17,7 +17,7 @@ namespace fiducial_vlam
   private:
     bool is_valid_{false};
     tf2::Transform transform_;
-    cov_type cov_;
+    cov_type cov_{};
 
     static tf2::Transform to_transform(const mu_type &mu)
     {

--- a/fiducial_vlam/include/vloc_context.hpp
+++ b/fiducial_vlam/include/vloc_context.hpp
@@ -110,8 +110,9 @@ namespace fiducial_vlam
 
   struct VlocContext
   {
-    rclcpp::Node & node_;
-    VlocContext(rclcpp::Node &node) :
+    rclcpp::Node &node_;
+
+    explicit VlocContext(rclcpp::Node &node) :
       node_{node}
     {}
 

--- a/fiducial_vlam/include/vloc_context.hpp
+++ b/fiducial_vlam/include/vloc_context.hpp
@@ -62,6 +62,9 @@ namespace fiducial_vlam
   CXT_MACRO_MEMBER(       /* non-zero => publish the tf of the camera at every frame  */ \
   publish_tfs,  \
   int, 1) \
+  CXT_MACRO_MEMBER(       /* non-zero => publish the camera tf as determined by each visible marker  */ \
+  publish_marker_tfs,  \
+  int, 1) \
   CXT_MACRO_MEMBER(       /* non-zero => publish the odometry of the camera at every frame  */ \
   publish_camera_odom,  \
   int, 1) \
@@ -93,6 +96,10 @@ namespace fiducial_vlam
   CXT_MACRO_MEMBER(       /* camera=>baselink transform component */ \
   t_camera_base_yaw, \
   double, 0.) \
+  \
+  CXT_MACRO_MEMBER(       /* subscribe to camera_info with best_effort (gazebo camera) not reliable (tello_ros) */ \
+  sub_camera_info_best_effort_not_reliable, \
+  int, 0) \
   /* End of list */
 
 #define VLOC_ALL_OTHERS \

--- a/fiducial_vlam/include/vloc_context.hpp
+++ b/fiducial_vlam/include/vloc_context.hpp
@@ -62,8 +62,8 @@ namespace fiducial_vlam
   CXT_MACRO_MEMBER(       /* non-zero => publish the tf of the camera at every frame  */ \
   publish_tfs,  \
   int, 1) \
-  CXT_MACRO_MEMBER(       /* non-zero => publish the camera tf as determined by each visible marker  */ \
-  publish_marker_tfs,  \
+  CXT_MACRO_MEMBER(       /* non-zero => publish the camera tf/pose as determined by each visible marker  */ \
+  publish_tfs_per_marker,  \
   int, 1) \
   CXT_MACRO_MEMBER(       /* non-zero => publish the odometry of the camera at every frame  */ \
   publish_camera_odom,  \
@@ -97,7 +97,7 @@ namespace fiducial_vlam
   t_camera_base_yaw, \
   double, 0.) \
   \
-  CXT_MACRO_MEMBER(       /* subscribe to camera_info with best_effort (gazebo camera) not reliable (tello_ros) */ \
+  CXT_MACRO_MEMBER(       /* subscribe to camera_info message with best_effort (gazebo camera) not reliable (tello_ros) */ \
   sub_camera_info_best_effort_not_reliable, \
   int, 0) \
   /* End of list */

--- a/fiducial_vlam/include/vmap_context.hpp
+++ b/fiducial_vlam/include/vmap_context.hpp
@@ -86,12 +86,13 @@ namespace fiducial_vlam
 
   struct VmapContext
   {
-    rclcpp::Node & node_;
-    VmapContext(rclcpp::Node &node) :
-    node_{node}
+    rclcpp::Node &node_;
+
+    explicit VmapContext(rclcpp::Node &node) :
+      node_{node}
     {}
 
-    #undef CXT_MACRO_MEMBER
+#undef CXT_MACRO_MEMBER
 #define CXT_MACRO_MEMBER(n, t, d) CXT_MACRO_DEFINE_MEMBER(n, t, d)
     VMAP_ALL_PARAMS
     VMAP_ALL_OTHERS

--- a/fiducial_vlam/launch/launch_one.py
+++ b/fiducial_vlam/launch/launch_one.py
@@ -110,6 +110,8 @@ def generate_launch_description():
                     'map_init_pose_z': -0.035,
                     'camera_frame_id': 'camera_link' + suffix,
                     'base_odometry_pub_topic': 'filtered_odom',
+                    'sub_camera_info_best_effort_not_reliable': 1,
+                    'publish_image_marked': 0,
                 }]),
 
             # Odometry filter takes camera pose, generates base_link odom, and publishes map to base_link tf

--- a/fiducial_vlam/launch/launch_one.py
+++ b/fiducial_vlam/launch/launch_one.py
@@ -12,6 +12,12 @@ def generate_launch_description():
     # 1 or more drones:
     drones = ['drone1']
 
+    tello_ros_args = [
+        [{
+            'drone_ip': '192.168.0.21',
+        }],
+    ]
+
     # Starting locations:
     starting_locations = [
         # Face the wall of markers in fiducial.world
@@ -111,7 +117,7 @@ def generate_launch_description():
                     'camera_frame_id': 'camera_link' + suffix,
                     'base_odometry_pub_topic': 'filtered_odom',
                     'sub_camera_info_best_effort_not_reliable': 1,
-                    'publish_image_marked': 0,
+                    'publish_image_marked': 1,
                 }]),
 
             # Odometry filter takes camera pose, generates base_link odom, and publishes map to base_link tf
@@ -124,7 +130,8 @@ def generate_launch_description():
 
             # Driver
             Node(package='tello_driver', node_executable='tello_driver', output='screen',
-                 node_name='tello_driver', node_namespace=namespace),
+                 node_name='tello_driver', node_namespace=namespace,
+                 parameters=tello_ros_args[idx]),
 
             # Drone controller
             Node(package='flock2', node_executable='drone_base', output='screen',

--- a/fiducial_vlam/launch/launch_one_gazebo.py
+++ b/fiducial_vlam/launch/launch_one_gazebo.py
@@ -107,6 +107,7 @@ def generate_launch_description():
                     'map_init_pose_z': -0.035,
                     'camera_frame_id': 'camera_link' + suffix,
                     'base_odometry_pub_topic': 'filtered_odom',
+                    'sub_camera_info_best_effort_not_reliable': 1,
                 }]),
 
             # Odometry filter takes camera pose, generates base_link odom, and publishes map to base_link tf

--- a/fiducial_vlam/src/fiducial_math.cpp
+++ b/fiducial_vlam/src/fiducial_math.cpp
@@ -50,8 +50,7 @@ namespace fiducial_vlam
 // CameraInfo class
 // ==============================================================================
 
-  CameraInfo::CameraInfo()
-  {}
+  CameraInfo::CameraInfo() = default;
 
   CameraInfo::CameraInfo(const sensor_msgs::msg::CameraInfo &camera_info_msg)
     : cv_(std::make_shared<CameraInfo::CvCameraInfo>(camera_info_msg))
@@ -77,7 +76,7 @@ namespace fiducial_vlam
     for (int i = 0; i < nMarkers; i++) {
 
       cv::Mat currentMarker = corners.getMat(i);
-      CV_Assert(currentMarker.total() == 4 && currentMarker.type() == CV_32FC2);
+      CV_Assert((currentMarker.total() == 4) && (currentMarker.type() == CV_32FC2));
 
       // draw marker sides
       for (int j = 0; j < 4; j++) {
@@ -116,11 +115,11 @@ namespace fiducial_vlam
     const CameraInfo ci_;
 
   public:
-    CvFiducialMath(const CameraInfo &camera_info)
+    explicit CvFiducialMath(const CameraInfo &camera_info)
       : ci_(camera_info)
     {}
 
-    CvFiducialMath(const sensor_msgs::msg::CameraInfo &camera_info_msg)
+    explicit CvFiducialMath(const sensor_msgs::msg::CameraInfo &camera_info_msg)
       : ci_(camera_info_msg)
     {}
 
@@ -166,7 +165,7 @@ namespace fiducial_vlam
 
       // If there are no known markers in the observation set, then don't
       // try to find the camera position
-      if (all_corners_f_map.size() < 1) {
+      if (all_corners_f_map.empty()) {
         return TransformWithCovariance{};
       }
 
@@ -257,7 +256,7 @@ namespace fiducial_vlam
       tf2::Vector3 corner2_f_marker(marker_length / 2.f, -marker_length / 2.f, 0.f);
       tf2::Vector3 corner3_f_marker(-marker_length / 2.f, -marker_length / 2.f, 0.f);
 
-      auto t_map_marker_tf = t_map_marker.transform();
+      const auto &t_map_marker_tf = t_map_marker.transform();
       auto corner0_f_map = t_map_marker_tf * corner0_f_marker;
       auto corner1_f_map = t_map_marker_tf * corner1_f_marker;
       auto corner2_f_map = t_map_marker_tf * corner2_f_marker;

--- a/fiducial_vlam/src/map.cpp
+++ b/fiducial_vlam/src/map.cpp
@@ -195,6 +195,33 @@ namespace fiducial_vlam
     return t_map_camera;
   }
 
+  std::vector<TransformWithCovariance> Localizer::markers_t_map_cameras(
+    const Observations &observations,
+    const std::vector<TransformWithCovariance> &t_map_markers,
+    FiducialMath &fm)
+  {
+    std::vector<TransformWithCovariance> t_map_cameras;
+
+    for (int i = 0; i < observations.size(); i += 1) {
+      TransformWithCovariance t_map_camera{};
+      auto &t_map_marker = t_map_markers[i];
+
+      if (t_map_marker.is_valid()) {
+        Observations single_observation{};
+        single_observation.add(observations.observations()[i]);
+        std::vector<TransformWithCovariance> single_t_map_markers{};
+        single_t_map_markers.emplace_back(t_map_marker);
+        t_map_camera = fm.solve_t_map_camera(single_observation, single_t_map_markers, map_->marker_length());
+      }
+
+      t_map_cameras.emplace_back(t_map_camera);
+    }
+
+    auto t_map_camera = fm.solve_t_map_camera(observations, t_map_markers, map_->marker_length());
+
+    return t_map_cameras;
+  }
+
 // ==============================================================================
 // Utility
 // ==============================================================================

--- a/fiducial_vlam/src/map.cpp
+++ b/fiducial_vlam/src/map.cpp
@@ -217,8 +217,6 @@ namespace fiducial_vlam
       t_map_cameras.emplace_back(t_map_camera);
     }
 
-    auto t_map_camera = fm.solve_t_map_camera(observations, t_map_markers, map_->marker_length());
-
     return t_map_cameras;
   }
 

--- a/fiducial_vlam/src/vloc_node.cpp
+++ b/fiducial_vlam/src/vloc_node.cpp
@@ -144,7 +144,8 @@ namespace fiducial_vlam
       // then just make an empty image pointer. The routines need to check
       // that the pointer is valid before drawing into it.
       cv_bridge::CvImagePtr color_marked;
-      if (cxt_.publish_image_marked_) {
+      if (cxt_.publish_image_marked_ &&
+          count_subscribers(cxt_.image_marked_pub_topic_) > 0) {
         color_marked = color;
       }
 
@@ -220,7 +221,7 @@ namespace fiducial_vlam
             }
 
             // if requested, publish the camera tf as determined from each marker.
-            if (cxt_.publish_marker_tfs_) {
+            if (cxt_.publish_tfs_per_marker_) {
               auto t_map_cameras = localizer_.markers_t_map_cameras(observations, t_map_markers, fm);
               auto tf_message = to_markers_tf_message(stamp, observations, t_map_cameras);
               if (!tf_message.transforms.empty()) {

--- a/fiducial_vlam/src/vloc_node.cpp
+++ b/fiducial_vlam/src/vloc_node.cpp
@@ -127,6 +127,9 @@ namespace fiducial_vlam
           map_ = std::make_unique<Map>(*msg);
         });
 
+      (void) camera_info_sub_;
+      (void) image_raw_sub_;
+      (void) map_sub_;
       RCLCPP_INFO(get_logger(), "vloc_node ready");
     }
 
@@ -220,7 +223,7 @@ namespace fiducial_vlam
             if (cxt_.publish_marker_tfs_) {
               auto t_map_cameras = localizer_.markers_t_map_cameras(observations, t_map_markers, fm);
               auto tf_message = to_markers_tf_message(stamp, observations, t_map_cameras);
-              if (tf_message.transforms.size() > 0) {
+              if (!tf_message.transforms.empty()) {
                 tf_message_pub_->publish(tf_message);
               }
             }
@@ -265,12 +268,12 @@ namespace fiducial_vlam
 
       // The camera_frame_id parameter is non-empty to publish the camera tf.
       // The base_frame_id parameter is non-empty to publish the base tf.
-      if (cxt_.camera_frame_id_.size()) {
+      if (!cxt_.camera_frame_id_.empty()) {
         msg.child_frame_id = cxt_.camera_frame_id_;
         msg.transform = tf2::toMsg(t_map_camera.transform());
         tf_message.transforms.emplace_back(msg);
       }
-      if (cxt_.base_frame_id_.size()) {
+      if (!cxt_.base_frame_id_.empty()) {
         msg.child_frame_id = cxt_.base_frame_id_;
         msg.transform = tf2::toMsg(t_map_base.transform());
         tf_message.transforms.emplace_back(msg);
@@ -296,7 +299,7 @@ namespace fiducial_vlam
 
         if (t_map_camera.is_valid()) {
 
-          if (cxt_.camera_frame_id_.size()) {
+          if (!cxt_.camera_frame_id_.empty()) {
             std::ostringstream oss_child_frame_id;
             oss_child_frame_id << cxt_.camera_frame_id_ << "_m" << std::setfill('0') << std::setw(3)
                                << observation.id();
@@ -337,7 +340,7 @@ int main(int argc, char **argv)
 
   // Create node
   auto node = std::make_shared<fiducial_vlam::VlocNode>();
-  auto result = rcutils_logging_set_logger_level(node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_INFO);
+  (void) rcutils_logging_set_logger_level(node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_INFO);
 
   // Spin until rclcpp::ok() returns false
   rclcpp::spin(node);

--- a/fiducial_vlam/src/vloc_node.cpp
+++ b/fiducial_vlam/src/vloc_node.cpp
@@ -340,7 +340,8 @@ int main(int argc, char **argv)
 
   // Create node
   auto node = std::make_shared<fiducial_vlam::VlocNode>();
-  (void) rcutils_logging_set_logger_level(node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_INFO);
+  auto result = rcutils_logging_set_logger_level(node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_INFO);
+  (void) result;
 
   // Spin until rclcpp::ok() returns false
   rclcpp::spin(node);

--- a/fiducial_vlam/src/vmap_context.cpp
+++ b/fiducial_vlam/src/vmap_context.cpp
@@ -9,7 +9,7 @@ namespace fiducial_vlam
   {
 #undef CXT_MACRO_MEMBER
 #define CXT_MACRO_MEMBER(n, t, d) CXT_MACRO_LOAD_PARAMETER(node_, (*this), n, t, d)
-    CXT_MACRO_INIT_PARAMETERS(VMAP_ALL_PARAMS, validate_parameters);
+    CXT_MACRO_INIT_PARAMETERS(VMAP_ALL_PARAMS, validate_parameters)
 
 
 #undef CXT_MACRO_MEMBER

--- a/fiducial_vlam/src/vmap_node.cpp
+++ b/fiducial_vlam/src/vmap_node.cpp
@@ -635,7 +635,8 @@ int main(int argc, char **argv)
 
   // Create node
   auto node = std::make_shared<fiducial_vlam::VmapNode>();
-  (void) rcutils_logging_set_logger_level(node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_INFO);
+  auto result = rcutils_logging_set_logger_level(node->get_logger().get_name(), RCUTILS_LOG_SEVERITY_INFO);
+  (void) result;
 
   // Spin until rclcpp::ok() returns false
   rclcpp::spin(node);


### PR DESCRIPTION
A couple of enhancements:
1) Ignore image_raw if the timestamp hasn't changed
2) Don't create image_marked if there are no subscribers
3) Publish tf of camera determined by each marker. For diagnostics, this will indicate each marker's contribution to the average and will show outliers.