### PR TITLE
image_marked honors stamp_msgs_with_current_time

### DIFF
--- a/fiducial_vlam/src/vloc_node.cpp
+++ b/fiducial_vlam/src/vloc_node.cpp
@@ -254,6 +254,9 @@ namespace fiducial_vlam
       if (color_marked) {
         // The marking has been happening on the original message.
         // Republish it now.
+        if (cxt_.stamp_msgs_with_current_time_) {
+          image_msg->header.stamp = now();
+        }
         image_marked_pub_->publish(std::move(image_msg));
       }
     }


### PR DESCRIPTION
Small fix: stamp image_marked with now() if cxt_.stamp_msgs_with_current_time is true.

This allows rviz to display image_marked when running a simulation on wall time, not sim time.